### PR TITLE
NEXT-24269 - replace drop-shadow with box-shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Updated Webpack in Storybook to version 5
+- Changed drop-shadow to box-shadow in "sw-card" to improve performance in Safari

--- a/src/components/assets/scss/mixins.scss
+++ b/src/components/assets/scss/mixins.scss
@@ -84,5 +84,5 @@
 }
 
 @mixin drop-shadow-default() {
-    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 8%)) drop-shadow(0 2px 1px rgba(0, 0, 0, 6%)) drop-shadow(0 1px 3px rgba(0, 0, 0, 10%));
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 8%), 0 2px 1px rgba(0, 0, 0, 6%), 0 1px 3px rgba(0, 0, 0, 10%);
 }

--- a/src/components/layout/sw-card/sw-card.vue
+++ b/src/components/layout/sw-card/sw-card.vue
@@ -228,6 +228,7 @@ export default Vue.extend({
 
     &:not(&--hero) {
         @include drop-shadow-default;
+        border-radius: $border-radius-lg;
     }
 
     &.sw-card--grid {


### PR DESCRIPTION
Drop-Shadow causes huge performance problems in Safari. That's why we switch to box-shadow