### PR TITLE
Fix wrong visibleValues in sw-select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [1.0.2] - 30.12.2022
+### Changed
+
+- Changed `visibleValues` computed property in `sw-select` to correctly display selected value for single select component.
 
 ### BREAKING CHANGES
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/meteor-component-library",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-tsc --noEmit --declaration false && eslint --ext .js,.ts,.vue src",

--- a/src/components/form/sw-select/sw-select.interactive.stories.js
+++ b/src/components/form/sw-select/sw-select.interactive.stories.js
@@ -84,6 +84,18 @@ VisualTestSingleSelection.play = async ({ args }) => {
   });
   expect(args.change).toHaveBeenCalledWith('f')
   expect(canvas.getByRole('textbox').value).toBe('');
+
+  // Only 'FF' is selected
+  await userEvent.type(canvas.getByRole('textbox'), 'FF');
+  popover = within(document.querySelector('.sw-popover__wrapper'));
+  await userEvent.click(popover.getByTestId('sw-select-option--ff'));
+  expect(args.itemAdd).toHaveBeenCalledWith({
+    id: 7,
+    value: 'ff',
+    label: 'Option FF',
+  });
+  expect(args.change).toHaveBeenCalledWith('ff');
+  expect(canvas.getByRole('textbox').value).toBe('');
 };
 
 export const VisualTestMultiSelect = Template.bind();

--- a/src/components/form/sw-select/sw-select.stories.js
+++ b/src/components/form/sw-select/sw-select.stories.js
@@ -35,6 +35,11 @@ export default {
         id: 6,
         label: 'Option F',
         value: 'f',
+      },
+      {
+        id: 7,
+        label: 'Option FF',
+        value: 'ff',
       }
     ],
   },

--- a/src/components/form/sw-select/sw-select.vue
+++ b/src/components/form/sw-select/sw-select.vue
@@ -325,7 +325,7 @@ export default Vue.extend({
         return [];
       }
 
-      return this.options.filter((item) => this.currentValue.includes(this.getKey(item, this.valueProperty))).slice(0, this.limit);
+      return this.options.filter((item) => this.isSelected(item)).slice(0, this.limit);
     },
 
     totalValuesCount(): number {
@@ -385,7 +385,11 @@ export default Vue.extend({
 
   methods: {
     isSelected(item: any) {
-      return this.currentValue.includes(this.getKey(item, this.valueProperty));
+      if (this.enableMultiSelection) {
+        return this.currentValue.includes(this.getKey(item, this.valueProperty));
+      }
+
+      return this.currentValue === this.getKey(item, this.valueProperty);
     },
 
     addItem(item: any) {


### PR DESCRIPTION
### Issue
The current `visibleValues` computed property is using `includes` method which leads to a bug when for example, the options can be like this:
```js
const options = [
  {
    label: '100',
   value: '100'
  },
  {
    label: '1000',
   value: '1000'
  }
]
```

In the above case, `visibleValues` will result in an array of ['100', '1000'] which is not expected when you only use single select.

![image](https://user-images.githubusercontent.com/24885765/209637579-46cea1df-5f6d-4a5d-aac2-69b0b29f2ac6.png)

### Solution
Treat the value of single select and multi-select separately, and only use `includes` method when checking the value for multi-select.